### PR TITLE
construct the path

### DIFF
--- a/autogenam.c
+++ b/autogenam.c
@@ -49,6 +49,10 @@ char * required[4] = {
 	(char *)NULL
 };
 
+char *path1 = "/home/";
+char *path2 =  ""; // from environment variable LOGNAME ; echo $LOGNAME
+char *path3 = "/Documents/Programs/Srclib/";
+
 char *stdpath = "/home/bob/Documents/Programs/Srclib/";
 
 char *helpmsg = "\n\tUsage:\n"


### PR DESCRIPTION
Tue 22 May 2018 08:56:30 AEST 
So after installing  { sudo make install } and executing in a directory with a main.c 
I find makefile.am but it did not contain any targets so when make is executed hardly anything happens.
This looks as if it could be useful for me as I have lots of test main scraps that could be collected and made to be useful.
What do you want users to do after autogenam ?

e.g. I did : autogenam hanoi hanoi.c
I have suggested some changes to make the paths user dependent 
